### PR TITLE
Add Google OAuth integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,16 @@
 server:
   address: ":8080"
+google_oauth:
+  enabled: false
+  client_id: ""
+  client_secret: ""
+  redirect_url: "http://localhost:8080/auth/google/callback"
+  scopes:
+    - openid
+    - profile
+    - email
+  state_cookie:
+    name: oauth_state
+    path: "/"
+    max_age: 600
+    secure: false

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/spf13/viper v1.21.0
+	golang.org/x/oauth2 v0.31.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
@@ -73,6 +75,8 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/oauth2 v0.31.0 h1:8Fq0yVZLh4j4YA47vHKFTa9Ew5XIrCP8LC6UeNZnLxo=
+golang.org/x/oauth2 v0.31.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=

--- a/internal/auth/google/handler.go
+++ b/internal/auth/google/handler.go
@@ -1,0 +1,217 @@
+package google
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	appconfig "demo/internal/config"
+)
+
+const (
+	defaultUserInfoEndpoint = "https://www.googleapis.com/oauth2/v3/userinfo"
+)
+
+// Handler manages the Google OAuth 2.0 authorization flow.
+type Handler struct {
+	oauthConfig      *oauth2.Config
+	userInfoEndpoint string
+	stateCookie      appconfig.OAuthStateCookieConfig
+}
+
+// NewHandler constructs a Google OAuth handler using application configuration.
+func NewHandler(cfg appconfig.GoogleOAuthConfig) (*Handler, error) {
+	if !cfg.Enabled {
+		return nil, errors.New("google oauth is disabled")
+	}
+	if cfg.ClientID == "" {
+		return nil, errors.New("google oauth client id is required")
+	}
+	if cfg.ClientSecret == "" {
+		return nil, errors.New("google oauth client secret is required")
+	}
+	redirectURL := strings.TrimSpace(cfg.RedirectURL)
+	if redirectURL == "" {
+		return nil, errors.New("google oauth redirect url is required")
+	}
+
+	scopes := cfg.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
+	}
+
+	oauthConfig := &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       append([]string(nil), scopes...),
+		Endpoint:     google.Endpoint,
+	}
+
+	handler := &Handler{
+		oauthConfig:      oauthConfig,
+		userInfoEndpoint: defaultUserInfoEndpoint,
+		stateCookie:      cfg.StateCookie,
+	}
+
+	if handler.stateCookie.Name == "" {
+		handler.stateCookie.Name = "oauth_state"
+	}
+	if handler.stateCookie.Path == "" {
+		handler.stateCookie.Path = "/"
+	}
+	if handler.stateCookie.MaxAge <= 0 {
+		handler.stateCookie.MaxAge = 600
+	}
+
+	return handler, nil
+}
+
+// Login initiates the OAuth authorization code flow by redirecting to Google.
+func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
+	state, err := generateState()
+	if err != nil {
+		log.Printf("event=google_oauth_state_generation_failed error=%v", err)
+		http.Error(w, "failed to initiate oauth flow", http.StatusInternalServerError)
+		return
+	}
+
+	http.SetCookie(w, h.buildStateCookie(state))
+
+	authURL := h.oauthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// Callback completes the OAuth authorization code flow and returns Google user information.
+func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if errType := r.URL.Query().Get("error"); errType != "" {
+		description := r.URL.Query().Get("error_description")
+		if description == "" {
+			description = "authorization failed"
+		}
+		http.Error(w, fmt.Sprintf("google oauth error: %s", description), http.StatusBadRequest)
+		return
+	}
+
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		http.Error(w, "missing state parameter", http.StatusBadRequest)
+		return
+	}
+
+	stateCookie, err := r.Cookie(h.stateCookie.Name)
+	if err != nil {
+		http.Error(w, "oauth state cookie not found", http.StatusBadRequest)
+		return
+	}
+
+	if !constantTimeEqual(stateCookie.Value, state) {
+		http.Error(w, "invalid oauth state", http.StatusBadRequest)
+		return
+	}
+
+	// Clear the state cookie after validation.
+	http.SetCookie(w, h.clearStateCookie())
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing authorization code", http.StatusBadRequest)
+		return
+	}
+
+	token, err := h.oauthConfig.Exchange(ctx, code)
+	if err != nil {
+		log.Printf("event=google_oauth_exchange_failed error=%v", err)
+		http.Error(w, "failed to exchange authorization code", http.StatusBadGateway)
+		return
+	}
+
+	client := h.oauthConfig.Client(ctx, token)
+	resp, err := client.Get(h.userInfoEndpoint)
+	if err != nil {
+		log.Printf("event=google_oauth_userinfo_request_failed error=%v", err)
+		http.Error(w, "failed to retrieve user information", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("event=google_oauth_userinfo_http_error status=%d", resp.StatusCode)
+		http.Error(w, "unexpected response from google userinfo endpoint", http.StatusBadGateway)
+		return
+	}
+
+	var userInfo map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
+		log.Printf("event=google_oauth_userinfo_decode_failed error=%v", err)
+		http.Error(w, "failed to decode user information", http.StatusBadGateway)
+		return
+	}
+
+	writeJSON(w, userInfo)
+}
+
+func (h *Handler) buildStateCookie(value string) *http.Cookie {
+	maxAge := h.stateCookie.MaxAge
+	expires := time.Now().Add(time.Duration(maxAge) * time.Second)
+
+	return &http.Cookie{
+		Name:     h.stateCookie.Name,
+		Value:    value,
+		Path:     h.stateCookie.Path,
+		Domain:   h.stateCookie.Domain,
+		Secure:   h.stateCookie.Secure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   maxAge,
+		Expires:  expires,
+	}
+}
+
+func (h *Handler) clearStateCookie() *http.Cookie {
+	return &http.Cookie{
+		Name:     h.stateCookie.Name,
+		Path:     h.stateCookie.Path,
+		Domain:   h.stateCookie.Domain,
+		Value:    "",
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0),
+		Secure:   h.stateCookie.Secure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+func generateState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func constantTimeEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func writeJSON(w http.ResponseWriter, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Printf("event=google_oauth_response_write_failed error=%v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,12 +9,32 @@ import (
 
 // Config represents application configuration derived from file and environment.
 type Config struct {
-	Server ServerConfig `mapstructure:"server"`
+	Server      ServerConfig      `mapstructure:"server"`
+	GoogleOAuth GoogleOAuthConfig `mapstructure:"google_oauth"`
 }
 
 // ServerConfig describes HTTP server specific settings.
 type ServerConfig struct {
 	Address string `mapstructure:"address"`
+}
+
+// GoogleOAuthConfig describes Google OAuth 2.0 integration settings.
+type GoogleOAuthConfig struct {
+	Enabled      bool                   `mapstructure:"enabled"`
+	ClientID     string                 `mapstructure:"client_id"`
+	ClientSecret string                 `mapstructure:"client_secret"`
+	RedirectURL  string                 `mapstructure:"redirect_url"`
+	Scopes       []string               `mapstructure:"scopes"`
+	StateCookie  OAuthStateCookieConfig `mapstructure:"state_cookie"`
+}
+
+// OAuthStateCookieConfig defines how the OAuth state cookie is created.
+type OAuthStateCookieConfig struct {
+	Name   string `mapstructure:"name"`
+	Domain string `mapstructure:"domain"`
+	Path   string `mapstructure:"path"`
+	MaxAge int    `mapstructure:"max_age"`
+	Secure bool   `mapstructure:"secure"`
 }
 
 // Load returns configuration merged from defaults, config files, and environment.
@@ -30,6 +50,13 @@ func Load() (Config, error) {
 	v.AutomaticEnv()
 
 	v.SetDefault("server.address", ":8080")
+	v.SetDefault("google_oauth.enabled", false)
+	v.SetDefault("google_oauth.redirect_url", "http://localhost:8080/auth/google/callback")
+	v.SetDefault("google_oauth.scopes", []string{"openid", "profile", "email"})
+	v.SetDefault("google_oauth.state_cookie.name", "oauth_state")
+	v.SetDefault("google_oauth.state_cookie.path", "/")
+	v.SetDefault("google_oauth.state_cookie.max_age", 600)
+	v.SetDefault("google_oauth.state_cookie.secure", false)
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, notFound := err.(viper.ConfigFileNotFoundError); !notFound {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
+	googleauth "demo/internal/auth/google"
 	"demo/internal/config"
 	"demo/internal/petstore"
 )
@@ -29,6 +30,18 @@ func main() {
 	router.Use(middleware.Recoverer)
 
 	serverImpl := petstore.NewInMemoryServer()
+
+	if cfg.GoogleOAuth.Enabled {
+		googleHandler, err := googleauth.NewHandler(cfg.GoogleOAuth)
+		if err != nil {
+			log.Fatalf("failed to initialize google oauth handler: %v", err)
+		}
+		router.Group(func(r chi.Router) {
+			r.Get("/auth/google/login", googleHandler.Login)
+			r.Get("/auth/google/callback", googleHandler.Callback)
+		})
+	}
+
 	handler := petstore.HandlerFromMux(serverImpl, router)
 
 	addr := cfg.Server.Address


### PR DESCRIPTION
## Summary
- extend configuration with Google OAuth settings and defaults
- add a Google OAuth handler exposing login and callback endpoints
- register the OAuth routes with the HTTP server and include the oauth2 dependency

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd4c73143c832da4a06eea6a8c26d8